### PR TITLE
sim_erp after dropping edge peaks

### DIFF
--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -424,11 +424,6 @@ class ERPparam():
             # Find peaks, and fit them with gaussians
             self.gaussian_params_ = self._fit_peaks(np.copy(self.signal))
 
-            # Calculate the peak fit
-            #   Note: if no peaks are found, this creates a flat (all zero) peak fit
-            self._peak_fit = sim_erp(self.time, np.ndarray.flatten(self.gaussian_params_), 
-                                        peak_mode='gaussian')
-
             # Convert gaussian definitions to peak parameters
             self.peak_params_  = self._create_peak_params(self.gaussian_params_)
 
@@ -438,6 +433,11 @@ class ERPparam():
             # drop peaks based on edge proximity (if shape could not be fit)
             self._drop_peaks_near_edge()
             self.peak_indices_ = self.peak_indices_.astype(int)
+
+            # Calculate the peak fit
+            #   Note: if no peaks are found, this creates a flat (all zero) peak fit
+            self._peak_fit = sim_erp(self.time, np.ndarray.flatten(self.gaussian_params_), 
+                                        peak_mode='gaussian')
 
             # Calculate R^2 and error of the model fit
             self._calc_r_squared()


### PR DESCRIPTION
Addresses Issue #7. This issue was due to the fact that ERPparam._peak_fit was generated before ERPparam._drop_peaks_near_edge() was called. 