### PR TITLE
fix to_df() bug (issue #4)

### DIFF
--- a/ERPparam/data/conversions.py
+++ b/ERPparam/data/conversions.py
@@ -51,7 +51,7 @@ def model_to_dict(fit_results, peak_org=None):
 
     if isinstance(peak_org, int):
         if len(peaks) < peak_org:
-            nans = [np.array([np.nan] * 13) for _ in range(peak_org-len(peaks))]
+            nans = [np.array([np.nan] * peaks.shape[1]) for _ in range(peak_org-len(peaks))]
             peaks = np.vstack((peaks, nans))
 
         for ind, peak in enumerate(peaks[:peak_org, :]):
@@ -62,7 +62,7 @@ def model_to_dict(fit_results, peak_org=None):
         for band, f_range in peak_org:
             band_peak = get_band_peak_arr(peaks, f_range)
             if band_peak[0] == np.nan:
-                band_peak = [np.nan] * 13
+                band_peak = [np.nan] * peaks.shape[1]
             for label, param in zip(indices, band_peak):
                 fr_dict[band + '_' + label.lower()] = param
 


### PR DESCRIPTION
This pull request addresses issue #4. 

If the number of peaks found is less than the max number designated by the peak_org argument, the dataframe values are filled with NaN. The number of NaN's was previously hard-coded to 13; the function has been updated to instead match this to the number of parameters (currently 15).