### PR TITLE
add correction method for overlapping peaks

### DIFF
--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -56,6 +56,7 @@ from ERPparam.core.errors import (FitError, NoModelError, DataError,
                                NoDataError, InconsistentDataError)
 from ERPparam.core.strings import (gen_settings_str, gen_results_fm_str,
                                 gen_issue_str, gen_width_warning_str, gen_model_exists_str)
+from ERPparam.core.corrections import correct_overlapping_peaks
 
 from ERPparam.plts.model import plot_ERPparam
 from ERPparam.utils.data import trim_signal
@@ -444,6 +445,10 @@ class ERPparam():
             # compute rise-decay symmetry
             self.shape_params_, self.peak_params_, self.peak_indices_ = \
                 self._compute_shape_params()
+
+            # correct overlapping peaks
+            self.peak_indices_ = correct_overlapping_peaks(self.signal, 
+                                                           self.peak_indices_)
 
             # drop peaks based on edge proximity (if shape could not be fit)
             self._drop_peaks_near_edge()

--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -980,24 +980,13 @@ class ERPparam():
         Find the indices of the peak and the half magnitude points.
         """
 
-        # get index of peak (find extreme value within a range around the model peak)
+        # get index of peak - find the raw signal voltage at the index closest to the extrema of the modelled Gaussian peak
         if self.peak_mode == "skewed_gaussian":
             params = gaussian_params
         else:
             params = gaussian_params[:3]
         model_compoment = sim_erp(self.time, params, peak_mode=self.peak_mode)
-        model_peak_index = np.argmax(np.abs(model_compoment))
-        peak_range_indices = int(np.floor(gaussian_params[2] * 2 * self.fs))
-        index_low = model_peak_index - peak_range_indices
-        if index_low < 0:
-            index_low = 0
-        index_high = model_peak_index + peak_range_indices
-        if index_high > len(self.signal):
-            index_high = len(self.signal)
-        if gaussian_params[1]>0:
-            peak_index = np.argmax(self.signal[index_low:index_high]) + index_low
-        else:
-            peak_index = np.argmin(self.signal[index_low:index_high]) + index_low
+        peak_index = np.argmax(np.abs(model_compoment))
 
         # compute half magnitude
         half_mag = self.signal[peak_index] / 2


### PR DESCRIPTION
if signal does not drop below half-magnitude between two peaks, find the trough and use this as the 'critical point' used to compute the shape parameters