### PR TITLE
add peak overlap correction

### DIFF
--- a/ERPparam/core/corrections.py
+++ b/ERPparam/core/corrections.py
@@ -1,0 +1,107 @@
+"""
+Correction functions for ERPparam.
+- correct_overlapping_peaks
+
+"""
+
+# imports
+import numpy as np
+
+
+def correct_overlapping_peaks(signal, peak_indices):
+    """ 
+    Correct the indices of overlapping peaks fit with ERPparam. If the
+    start of a peak overlaps with the previous peak, the start of the peak is
+    set to the trough between the peaks. If the end of a peak overlaps with the
+    next peak, the end of the peak is set to the trough between the peaks.
+    """
+
+    # find overlapping peaks and the troughs between them
+    overlap_start, overlap_end = _find_overlapping_peaks(peak_indices)
+    idx_trough = _find_troughs(signal, peak_indices, overlap_start, overlap_end)
+    
+    # update peak indices
+    for i_peak in range(len(peak_indices)):
+        if overlap_start[i_peak]:
+            peak_indices[i_peak][0] = idx_trough[i_peak]
+        if overlap_end[i_peak]:
+            peak_indices[i_peak][2] = idx_trough[i_peak+1]
+            
+    return peak_indices
+
+
+def _find_overlapping_peaks(peak_indices):
+    """
+    Find indices of overlapping peaks in a list of peak indices.
+
+    Parameters
+    ----------
+    peak_indices : list of tuples
+        List of tuples, where each tuple contains the start, peak, and end 
+        indices of a peak.
+
+    Returns
+    -------
+    overlap_start : 1d array
+        Boolean array indicating if the start of a peak overlaps with the 
+        previous peak.
+    overlap_end : 1d array
+        Boolean array indicating if the end of a peak overlaps with the next 
+        peak.
+    """
+
+    # chech if start of peak is before the previous peak
+    overlap_start = np.zeros(len(peak_indices), dtype=bool)
+    for i_peak in range(1, len(peak_indices)):
+        if peak_indices[i_peak][0] < peak_indices[i_peak-1][1]:
+            overlap_start[i_peak] = True
+
+    # check if end of peak is after the next peak
+    overlap_end = np.zeros(len(peak_indices), dtype=bool)
+    for i_peak in range(len(peak_indices)-1):
+        if peak_indices[i_peak][2] > peak_indices[i_peak+1][1]:
+            overlap_end[i_peak] = True
+
+
+    return overlap_start, overlap_end
+
+
+def _find_troughs(signal, peak_indices, overlap_start, overlap_end):
+    """
+    Find the troughs between overlapping peaks in a signal.
+
+    Parameters
+    ----------
+    signal : 1d array
+        Signal containing the peaks.
+    peak_indices : list of tuples
+        List of tuples, where each tuple contains the start, peak, and end
+        indices of a peak.
+    overlap_end : 1d array
+        Boolean array indicating which peaks have an ending index that overlaps
+        with the following peak.
+
+    Returns
+    -------
+    idx_trough : 1d array
+        Array of indices of the troughs between the overlapping peaks.
+    
+    """
+
+    # initialize
+    idx_trough = np.zeros_like(overlap_start) * np.nan
+    for i_overlap in range(len(overlap_start)):
+        if overlap_start[i_overlap]:
+            overlap = signal[int(peak_indices[i_overlap-1][1]) : \
+                             int(peak_indices[i_overlap][1])]
+            idx_trough[i_overlap] = np.argmin(overlap) + \
+                                        peak_indices[i_overlap-1][1]
+        
+    for i_overlap in range(len(overlap_start)-1):      
+        if overlap_end[i_overlap] and not overlap_start[i_overlap+1]:
+            overlap = signal[int(peak_indices[i_overlap][1]) : \
+                             int(peak_indices[i_overlap+1][1])]
+            idx_trough[i_overlap] = np.argmin(overlap) + \
+                                        peak_indices[i_overlap][1]
+            
+    return idx_trough

--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -980,24 +980,13 @@ class ERPparam():
         Find the indices of the peak and the half magnitude points.
         """
 
-        # get index of peak (find extreme value within a range around the model peak)
+        # get index of peak - find the raw signal voltage at the index closest to the extrema of the modelled Gaussian peak
         if self.peak_mode == "skewed_gaussian":
             params = gaussian_params
         else:
             params = gaussian_params[:3]
         model_compoment = sim_erp(self.time, params, peak_mode=self.peak_mode)
-        model_peak_index = np.argmax(np.abs(model_compoment))
-        peak_range_indices = int(np.floor(gaussian_params[2] * 2 * self.fs))
-        index_low = model_peak_index - peak_range_indices
-        if index_low < 0:
-            index_low = 0
-        index_high = model_peak_index + peak_range_indices
-        if index_high > len(self.signal):
-            index_high = len(self.signal)
-        if gaussian_params[1]>0:
-            peak_index = np.argmax(self.signal[index_low:index_high]) + index_low
-        else:
-            peak_index = np.argmin(self.signal[index_low:index_high]) + index_low
+        peak_index = np.argmax(np.abs(model_compoment))
 
         # compute half magnitude
         half_mag = self.signal[peak_index] / 2


### PR DESCRIPTION
if signal voltage does not drop below half-magnitude between two peaks, find the trough and use this as the "critical point" for computing the peak shape.

This addresses the issue of computing the width of overlapping peaks (#34)