### PR TITLE
add adjusted r-squared

### DIFF
--- a/ERPparam/core/info.py
+++ b/ERPparam/core/info.py
@@ -24,7 +24,7 @@ def get_description():
     - descriptors : descriptors of the object status and model results
     """
 
-    attributes = {'results' : ['gaussian_params_', 'shape_params_', 'peak_indices_', 'r_squared_', 'error_'],
+    attributes = {'results' : ['gaussian_params_', 'shape_params_', 'peak_indices_', 'r_squared_', 'error_', 'adj_r_squared_'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_height', 'peak_threshold', 'peak_mode', 'gauss_overlap_thresh', 'maxfev','amplitude_fraction'],
                   'data' : ['signal', 'time'],
                   'meta_data' : ['time_range', 'fs'],

--- a/ERPparam/core/strings.py
+++ b/ERPparam/core/strings.py
@@ -336,10 +336,11 @@ def gen_results_fm_str(fm, concise=False):
           for sp in fm.shape_params_],
         '',
 
-        # Goodness if fit
+        # Goodness of fit
         'Goodness of fit metrics:',
-        'R^2 of model fit is {:5.4f}'.format(fm.r_squared_),
-        'Error of the fit is {:5.4f}'.format(fm.error_),
+        '     R-squared: {:5.4f}'.format(fm.r_squared_),
+        '         Error: {:5.4f}'.format(fm.error_),
+        'Adj. R-squared: {:5.4f}'.format(fm.adj_r_squared_),
         '',
 
         # Footer
@@ -411,14 +412,13 @@ def gen_results_fg_str(fg, concise=False):
         #     'with' if fg.aperiodic_mode == 'knee' else 'without'),
         # '',
         'Peak Fit Values:',
-        *[el for el in ['    Amplitudes - Min: {:6.2f}, Max: {:6.2f}, Mean: {:5.2f}'
-                        .format(np.nanmin(pws), np.nanmax(pws), np.nanmean(pws)),
-                       ]],
+        'Amplitudes - Min: {:6.2f}, Max: {:6.2f}, Mean: {:5.2f}'
+        .format(np.nanmin(pws), np.nanmax(pws), np.nanmean(pws)),
         'Bandwidths - Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
         .format(np.nanmin(bws), np.nanmax(bws), np.nanmean(bws)),
-        'Symmetry - Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
+        '  Symmetry - Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
         .format(np.nanmin(symmetry), np.nanmax(symmetry), np.nanmean(symmetry)),
-        'Sharpness - Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
+        ' Sharpness - Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
         .format(np.nanmin(sharpness), np.nanmax(sharpness), np.nanmean(sharpness)),
         '',
 
@@ -427,12 +427,14 @@ def gen_results_fg_str(fg, concise=False):
         .format(n_peaks),
         '',
 
-        # Goodness if fit
+        # Goodness of fit
         'Goodness of fit metrics:',
-        '   R2s -  Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
+        '        R2s -  Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
         .format(np.nanmin(r2s), np.nanmax(r2s), np.nanmean(r2s)),
-        'Errors -  Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
+        '     Errors -  Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
         .format(np.nanmin(errors), np.nanmax(errors), np.nanmean(errors)),
+        'Adjusted R2s -  Min: {:6.3f}, Max: {:6.3f}, Mean: {:5.3f}'
+        .format(np.nanmin(r2s), np.nanmax(r2s), np.nanmean(r2s)),
         '',
 
         # Footer

--- a/ERPparam/data/conversions.py
+++ b/ERPparam/data/conversions.py
@@ -65,6 +65,7 @@ def model_to_dict(fit_results, peak_org=None):
     # goodness-of-fit metrics
     fr_dict['error'] = fit_results.error
     fr_dict['r_squared'] = fit_results.r_squared
+    fr_dict['adj_r_squared'] = fit_results.adj_r_squared
 
     return fr_dict
 

--- a/ERPparam/data/data.py
+++ b/ERPparam/data/data.py
@@ -13,10 +13,14 @@ from collections import namedtuple
 ###################################################################################################
 ###################################################################################################
 
-class ERPparamSettings(namedtuple('ERPparamSettings', ['peak_width_limits', 'max_n_peaks',
-                                                 'min_peak_height', 'peak_threshold',
-                                                 'peak_mode', 'gauss_overlap_thresh', 'maxfev', 
-                                                 'amplitude_fraction'])):
+class ERPparamSettings(namedtuple('ERPparamSettings', ['peak_width_limits', 
+                                                       'max_n_peaks',
+                                                       'min_peak_height', 
+                                                       'peak_threshold',
+                                                       'peak_mode', 
+                                                       'gauss_overlap_thresh', 
+                                                       'maxfev', 
+                                                       'amplitude_fraction'])):
     """User defined settings for the fitting algorithm.
     Parameters
     ----------
@@ -30,6 +34,10 @@ class ERPparamSettings(namedtuple('ERPparamSettings', ['peak_width_limits', 'max
         Relative threshold for detecting peaks, in units of standard deviation of the input data.
     peak_mode : {'gaussian', 'skewed_gaussian'}
         Mode for fitting the peaks.
+    gauss_overlap_thresh : float
+        Overlap threshold for Gaussian peaks, as a fraction of the peak width.
+    maxfev : int
+        Maximum number of function evaluations for the fitting algorithm.
     amplitude_fraction : float, optional, default: 0.5
         Fraction of the peak amplitude to use as a threshold for computing
         the shape parameters of the ERP peak.
@@ -58,17 +66,16 @@ class ERPparamMetaData(namedtuple('ERPparamMetaData', ['time_range', 'fs'])):
     __slots__ = ()
 
 
-class ERPparamResults(namedtuple('ERPparamResults', ['r_squared', 'error', 
-                                                     'gaussian_params','shape_params',
-                                                     'peak_indices'])):
+class ERPparamResults(namedtuple('ERPparamResults', ['gaussian_params',
+                                                     'shape_params',
+                                                     'peak_indices',
+                                                     'r_squared', 
+                                                     'error',
+                                                     'adj_r_squared'])):
     """Model results from parameterizing a power spectrum.
 
     Parameters
     ----------
-    r_squared : float
-        R-squared of the fit between the full model fit and the input data.
-    error : float
-        Error of the full model fit.
     gaussian_params : 2d array
         Parameters that define the gaussian fit( s).
         Each row is a gaussian, as [mean, height, standard deviation].
@@ -78,6 +85,12 @@ class ERPparamResults(namedtuple('ERPparamResults', ['r_squared', 'error',
         sharpness, rising sharpeness, decaying sharpeness, CF, PW, BW].
     peak_indices : 1d array, 
         Indices of the peaks in the input data.
+    r_squared : float
+        R-squared of the fit between the full model fit and the input data.
+    error : float
+        Error of the full model fit.
+    adj_r_squared : float
+        Adjusted R-squared of the fit between the full model fit and the input data.
 
     Notes
     -----

--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -114,10 +114,14 @@ class ERPparam():
         ERP shape parameters for each peak.
         Each row is a peak, as [duration, rise-time, decay-time, rise-decay symmetry,
         FWHM, rising sharpness, decaying sharpness].
+    peak_indices_ : 1d array
+        Indices of the peaks and half-magnitude points in the signal.
     r_squared_ : float
         R-squared of the fit between the input signal and the full model fit.
     error_ : float
         Error of the full model fit.
+    adj_r_squared_ : float
+        Adjusted R-squared of the fit between the input signal and the full model fit.
     n_peaks_ : int
         The number of peaks fit in the model.
     has_data : bool
@@ -258,6 +262,7 @@ class ERPparam():
             self.shape_params_ = np.ones([0,11])*np.nan
             self.r_squared_ = np.nan
             self.error_ = np.nan
+            self.adj_r_squared_ = np.nan
             self.peak_indices_ = np.full(3, np.nan)
             self._peak_fit = None
 
@@ -340,6 +345,7 @@ class ERPparam():
         self.peak_indices_ = ERPparam_result.peak_indices
         self.r_squared_ = ERPparam_result.r_squared
         self.error_ = ERPparam_result.error
+        self.adj_r_squared_ = ERPparam_result.adj_r_squared
 
         self._check_loaded_results(ERPparam_result._asdict())
 
@@ -462,6 +468,7 @@ class ERPparam():
             # Calculate R^2 and error of the model fit
             self._calc_r_squared()
             self._calc_error()
+            self._calc_adj_r_squared()
 
         except FitError:
 
@@ -552,7 +559,7 @@ class ERPparam():
 
         Parameters
         ----------
-        name : {'gaussian_params', 'shape_params', 'error', 'r_squared'}
+        name : {'gaussian_params', 'shape_params', 'error', 'r_squared', 'adj_r_squared'}'}
             Name of the data field to extract.
         col : {'MN','HT','SD', 'SK'}, {CT, PW, BW, SK, FWHM, rise_time, decay_time, symmetry,
             sharpness, sharpness_rise, sharpness_decay} or int, optional
@@ -1197,10 +1204,28 @@ class ERPparam():
 
 
     def _calc_r_squared(self):
-        """Calculate the r-squared goodness of fit of the model, compared to the original data."""
+        """Calculate the r-squared goodness of fit of the model compared to the 
+        original data."""
 
         r_val = np.corrcoef(self.signal, self._peak_fit)
         self.r_squared_ = r_val[0][1] ** 2
+
+
+    def _calc_adj_r_squared(self):
+        """Calculate the adjusted r-squared goodness of fit of the model 
+        compared to the original data. This measure accounts for the number of 
+        parameters in the model using the formula:
+        adj_r_squared = 1 - (1 - r_squared) * (n - 1) / (n - p - 1)
+        where n is the number of data points, and p is the number of parameters 
+        in the model.
+        """
+
+        n = len(self.signal)
+        if self.peak_mode == 'skewed_gaussian':
+            p = self.gaussian_params_.shape[0] * 4
+        elif self.peak_mode == 'gaussian':
+            p = self.gaussian_params_.shape[0] * 3
+        self.adj_r_squared_ = 1 - (1 - self.r_squared_) * (n - 1) / (n - p - 1)
 
 
     def _calc_error(self, metric=None):

--- a/ERPparam/objs/group.py
+++ b/ERPparam/objs/group.py
@@ -85,7 +85,7 @@ class ERPparamGroup(ERPparam):
       and the BW of the peak, is 2*std of the gaussian (as 'two sided' bandwidth).
     - The ERPparamGroup object inherits from the ERPparam object. As such it also has data
       attributes (`signal`), and parameter attributes
-      ( `shape_params_`, `gaussian_params_`, `r_squared_`, `error_`)
+      ( `shape_params_`, `gaussian_params_`, `peak_indices_`, `r_squared_`, `error_`, `adj_r_squared_`)
       which are defined in the context of individual model fits. These attributes are
       used during the fitting process, but in the group context do not store results
       post-fitting. Rather, all model fit results are collected and stored into the
@@ -196,9 +196,10 @@ class ERPparamGroup(ERPparam):
         """
         format_dict = { 'gaussian_params_' : np.ones([0,4])*np.nan,
                         'shape_params_' : np.ones([0,11])*np.nan,
+                        'peak_indices_' : np.full(3, np.nan),
                         'r_squared_': np.nan,
                         'error_' : np.nan,
-                        'peak_indices_' : np.full(3, np.nan)
+                        'adj_r_squared_' : np.nan
                     }
         empty_res = ERPparamResults(**{key.strip('_') : format_dict[key] \
             for key in OBJ_DESC['results']})
@@ -355,7 +356,7 @@ class ERPparamGroup(ERPparam):
 
         Parameters
         ----------
-        name : { 'gaussian_params','shape_params', 'error', 'r_squared'}
+        name : {'gaussian_params', 'shape_params', 'peak_indices', 'error', 'r_squared', 'adj_r_squared'}
             Name of the data field to extract across the group.
         col :   {'MN','HT','SD', 'SK'}, 
                 {'CT', 'PW', 'BW' 'SK', FWHM, rise_time, decay_time, symmetry, sharpness, sharpness_rise, 

--- a/ERPparam/tests/data/test_data.py
+++ b/ERPparam/tests/data/test_data.py
@@ -31,11 +31,12 @@ def test_ERPparam_meta_data():
 
 def test_ERPparam_results():
     # [ 'r_squared', 'error', 'gaussian_params','shape_params', 'peak_indices']
-    results = ERPparamResults(0.95, 
-                              0.05,
-                              [10, 0.5, 1], 
+    results = ERPparamResults([10, 0.5, 1], 
                               [0.05, 0.05, 0.025, 0.5, 0.97,  0.97, 0.98, 10, 0.5, 1], 
-                              [0]) 
+                              [0],
+                              0.95, 
+                              0.05,
+                              0.90) 
     assert results
 
     results_fields = OBJ_DESC['results']

--- a/ERPparam/tests/objs/test_fit.py
+++ b/ERPparam/tests/objs/test_fit.py
@@ -238,15 +238,13 @@ def test_add_data():
     # Test that prior data does not get cleared, when requesting not to clear
     tfm._reset_data_results(True, True, True)
     tfm.add_results(ERPparamResults(
-       r_squared=0.9973886245863048, error=0.01234299919871499, 
-       gaussian_params=np.asarray([[ 0.10157924,  1.8103013 ,  0.02937827],
-       [ 0.1980535 , -1.39908145,  0.04706476]]), 
-       shape_params=np.asarray([[0.064     , 0.04      , 0.024     , 0.625     , 0.97706828,
-        0.97134   , 0.98279656],
-       [0.103     , 0.041     , 0.062     , 0.39805825, 0.9560461 ,
-        0.96498029, 0.9471119 ]]), 
-        peak_indices=np.asarray([[562, 602, 626],
-       [657, 698, 760]])))
+        gaussian_params=np.asarray([[0.101,  1.810, 0.029],
+                                    [0.198, -1.399, 0.047]]), 
+        shape_params=np.asarray([[0.064, 0.04, 0.024, 0.625, 0.977, 0.971, 0.982],
+                                [0.103, 0.041, 0.062, 0.398, 0.956, 0.964, 0.947]]), 
+        peak_indices=np.asarray([[562, 602, 626], [657, 698, 760]]),
+        r_squared=0.97, error=0.01, adj_r_squared=0.95))
+
     tfm.add_data(time, signal, clear_results=False)
     assert tfm.has_data
     assert tfm.has_model
@@ -289,12 +287,12 @@ def test_add_results():
 
     # Test adding results
     ERPparam_results = ERPparamResults(
-        r_squared=0.99, error=0.01, 
-       gaussian_params=np.asarray([[ 0.10,  1.8 ,  0.02],
-                                    [ 0.19 , -1.39,  0.047]]), 
-       shape_params=np.asarray([[0.064 , 0.04 , 0.024, 0.625 , 0.97, 0.97   , 0.98],
-                                  [0.103 , 0.041 , 0.062 , 0.39, 0.951 , 0.964, 0.947 ]]), 
-        peak_indices=np.asarray([[562, 602, 626],  [657, 698, 760]]))
+        gaussian_params=np.asarray([[0.10, 1.8, 0.02], [0.19, -1.39, 0.047]]), 
+        shape_params=np.asarray([[0.064, 0.04, 0.024, 0.625, 0.97, 0.97, 0.98],
+                                  [0.103, 0.041, 0.062, 0.39, 0.951, 0.964, 0.947]]), 
+        peak_indices=np.asarray([[562, 602, 626],  [657, 698, 760]]),
+        r_squared=0.99, error=0.01, adj_r_squared=0.95)
+
     tfm.add_results(ERPparam_results)
     assert tfm.has_model
     for setting in OBJ_DESC['results']:

--- a/ERPparam/tests/tutils.py
+++ b/ERPparam/tests/tutils.py
@@ -58,7 +58,7 @@ def get_tresults():
     return ERPparamResults(shape_params=np.array([[0.08, 0.05, 0.02, 0.6, 0.97, 0.97, 0.98, 0.1, 2, 0.06], 
                                                   [0.08, 0.05, 0.02, 0.6, 0.97, 0.97, 0.98, 0.2, -1.5, 0.1]]), 
                            # [duration, rise-time, decay-time, rise-decay symmetry, FWHM, rising sharpness, decaying sharpness, CT, PW, BW]
-                           r_squared=0.97, error=0.01,
+                           r_squared=0.97, error=0.01, adj_r_squared=0.95,
                            gaussian_params=np.array([[0.1, 2, 0.03], [0.2, -1.5, 0.05]]), # [mean, height, standard deviation]
                            peak_indices=np.array([[1,2,3],[4,5,6]])
                            )


### PR DESCRIPTION
Add adjusted r-squared attribute (`adj_r_squared`) to `ERPparam`. This attribute has also been integrated into `ERPparamResults` and added to the results string printed by `ERPparam.report()`

Computed using the formula:
adj_r_squared = 1 - (1 - r_squared) * (n - 1) / (n - p - 1)
where n is the number of data points, and p is the number of parameters in the model.