### PR TITLE
Group baseline

### DIFF
--- a/ERPparam/objs/fit.py
+++ b/ERPparam/objs/fit.py
@@ -106,6 +106,12 @@ class ERPparam():
         Time range of the signal from which to estimate the noise threshold at which iterative peak fitting stops (typically a pre-stimulus window).
         Input as [earliest_time, latest_time].
         If unspecified, the whole time window before time 0 will be used. If that cannot be found, the whole length of signal will be used.
+    uncropped_time : 1d array
+        The uncropped version of the time vector, before trimming based on
+        the time_range attribute. This is useful for plotting.
+    uncropped_signal : 1d array
+        The uncropped version of the signal, before trimming based on
+        the time_range attribute. This is useful for plotting.
     fs : float
         Sampling frequency.
     gaussian_params_ : 2d array

--- a/ERPparam/objs/group.py
+++ b/ERPparam/objs/group.py
@@ -55,11 +55,11 @@ class ERPparamGroup(ERPparam):
     time_range : list of [float, float]
         Frequency range of the power spectra, as [lowest_freq, highest_freq].
     uncropped_time : 1d array
-        The uncropped version of the time vector, before any trimming.
-        This is useful for visualizing the original time vector.
+        The uncropped version of the time vector, before trimming based on
+        the time_range attribute.
     uncropped_signals : 1d array
-        The uncropped version of the signal, before any trimming.
-        This is useful for visualizing the original signal.
+        The uncropped version of the signal, before trimming based on
+        the time_range attribute.
     group_results : list of ERPparamResults
         Results of ERPparam model fit for each power spectrum.
     has_data : bool

--- a/ERPparam/objs/group.py
+++ b/ERPparam/objs/group.py
@@ -54,8 +54,12 @@ class ERPparamGroup(ERPparam):
         Power values are stored internally in log10 scale.
     time_range : list of [float, float]
         Frequency range of the power spectra, as [lowest_freq, highest_freq].
-    freq_res : float
-        Frequency resolution of the power spectra.
+    uncropped_time : 1d array
+        The uncropped version of the time vector, before any trimming.
+        This is useful for visualizing the original time vector.
+    uncropped_signals : 1d array
+        The uncropped version of the signal, before any trimming.
+        This is useful for visualizing the original signal.
     group_results : list of ERPparamResults
         Results of ERPparam model fit for each power spectrum.
     has_data : bool
@@ -308,8 +312,8 @@ class ERPparamGroup(ERPparam):
         if n_jobs == 1:
             self._reset_group_results(len(self.signals))
             for ind, signal in \
-                _progress(enumerate(self.signals), progress, len(self)):
-                self._fit(time=None, signal=signal, time_range=self.time_range, baseline=self.baseline)
+                _progress(enumerate(self.uncropped_signals), progress, len(self)):
+                self._fit(time=self.uncropped_time, signal=signal, time_range=self.time_range, baseline=self.baseline)
                 self.group_results[ind] = self._get_results()
 
         # Run in parallel
@@ -318,7 +322,7 @@ class ERPparamGroup(ERPparam):
             n_jobs = cpu_count() if n_jobs == -1 else n_jobs
             with Pool(processes=n_jobs) as pool:
                 self.group_results = list(_progress(pool.imap(partial(_par_fit, fg=self),
-                                                              self.signals),
+                                                              self.uncropped_signals),
                                                     progress, len(self.signals)))
 
         # Clear the individual power spectrum and fit results of the current fit``
@@ -677,7 +681,7 @@ class ERPparamGroup(ERPparam):
 def _par_fit(signal, fg):
     """Helper function for running in parallel."""
 
-    fg._fit(time=fg.time, signal=signal, time_range=fg.time_range, baseline=fg.baseline)
+    fg._fit(time=fg.uncropped_time, signal=signal, time_range=fg.time_range, baseline=fg.baseline)
 
     return fg._get_results()
 


### PR DESCRIPTION
This addresses the baseline bug (#53) in ERPparamGroup by passing the uncropped signal and time vector to the fit function.