### PR TITLE
fix bug in ERPparamGroup plot

### DIFF
--- a/ERPparam/plts/fg.py
+++ b/ERPparam/plts/fg.py
@@ -77,8 +77,8 @@ def plot_fg_pks(fg, ax=None, **plot_kwargs):
     """
 
     
-    plot_scatter_2(fg.get_params('shape_params', 'width'), 'Bandwidth',
-                   fg.get_params('shape_params', "amplitude"), 'Amplitude',
+    plot_scatter_2(fg.get_params('shape_params', 'width')[:,0], 'Bandwidth',
+                   fg.get_params('shape_params', "amplitude")[:,0], 'Amplitude',
                     'Peak Fits', ax=ax)
 
 


### PR DESCRIPTION
peak index column was being plotted along with param

Addresses #79 