### PR TITLE
update ERPparamGroup.has_data() to check for time argument.

### DIFF
--- a/ERPparam/objs/group.py
+++ b/ERPparam/objs/group.py
@@ -129,7 +129,7 @@ class ERPparamGroup(ERPparam):
     def has_data(self):
         """Indicator for if the object contains data."""
 
-        return True if np.any(self.signals) else False
+        return True if (np.any(self.signals) and np.any(self.time)) else False
 
 
     @property


### PR DESCRIPTION
Addresses issue #54. ERPparam.has_data() checks for both `signal` and `time`, while ERPparamGroup.has_data() only checks for `signals`. The latter has been updated here to have the same behavior.